### PR TITLE
[WIP] Demo configuration for appending routes

### DIFF
--- a/Tests/Functional/app/config/default.yml
+++ b/Tests/Functional/app/config/default.yml
@@ -4,4 +4,4 @@ imports:
     - { resource: monolog.yml }
     - { resource: doctrine.yml }
     - { resource: phpcrodm.yml }
-    - { resource: routingautoroute.yml }
+    - { resource: routing/autoroutes.yml }

--- a/Tests/Functional/app/config/routing/autoroutes.yml
+++ b/Tests/Functional/app/config/routing/autoroutes.yml
@@ -34,6 +34,8 @@ symfony_cmf_routing_auto:
                     pattern: -%d
                 not_exists_action: 
                     strategy: create
+                append:
+                    import: @SymfonyCmfRoutingAutoBundle/Tests/Functional/app/config/routing/extrablogroutes.yml
 
         ##
         # e.g. /cms/auto-route/blog/my-blogs-title/2013-04-09/my-post-title

--- a/Tests/Functional/app/config/routing/extrablogroutes.yml
+++ b/Tests/Functional/app/config/routing/extrablogroutes.yml
@@ -1,0 +1,3 @@
+tag_route:
+    pattern: /{tag}
+    defaults: { _controller: SymfonyCmfRoutingAutoBundle:FooBar:Tag }


### PR DESCRIPTION
This is a potentially interesting feature, basically we allow the user to append routes generated from a normal routing.[yml|xml|php] file. Routes can be appended to any builder unit, both in the "content_path" and "content_name" sections.

This would solve the tagging routing issue in the BlogBundle and would also enable users to reuse existing route config files for bundles, for example, FOSUserBundle.

Also it should be fairly easy to implement.
