### PR TITLE
[WIP] basepath provider (or should we prefix route_basepath automatically)

### DIFF
--- a/AutoRoute/Exception/BadProviderPositionException.php
+++ b/AutoRoute/Exception/BadProviderPositionException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\RoutingAutoBundle\AutoRoute\Exception;
+
+/**
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class BadProviderPositionException extends \RuntimeException
+{
+}
+

--- a/AutoRoute/PathProvider/RouteBasePathProvider.php
+++ b/AutoRoute/PathProvider/RouteBasePathProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\RoutingAutoBundle\AutoRoute\PathProvider;
+
+use Symfony\Cmf\Bundle\RoutingAutoBundle\AutoRoute\PathProviderInterface;
+use Symfony\Cmf\Bundle\RoutingAutoBundle\AutoRoute\Exception\BadProviderPositionException;
+use Symfony\Cmf\Bundle\RoutingAutoBundle\AutoRoute\RouteStack;
+
+/**
+ * Provides the routing extra bundles route_basepath.
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class RouteBasePathObjectProvider implements PathProviderInterface
+{
+    protected $routingBasePath;
+
+    public function __construct($routeBasePath)
+    {
+        $this->routeBasePath = $routeBasePath;
+    }
+
+    public function init(array $options)
+    {
+    }
+
+    public function providePath(RouteStack $routeStack)
+    {
+        $context = $routeStack->getContext();
+
+        if (count($context->getRouteStacks()) > 0) {
+            throw new BadProviderPositionException(
+                'RouteBasePathProvider must belong to the first builder unit - adding '.
+                'the full routing basepath at an intermediate point would be senseless.'
+            );
+        }
+
+        $id = $this->routeBasePath;
+        $id = substr($id, 1);
+        $pathElements = explode('/', $id);
+        $routeStack->addPathElements($pathElements);
+    }
+}
+


### PR DESCRIPTION
The route base path provider provides the route base path as defined in `RoutingExtraBundle`.

Currently the path providers provide **full paths** so paths including, for example, the `cmf/routes` path, the `route_basepath` defined in routing extra.

The alternative to this is to use a specified provider

``` yaml
base:
  provider: specified
  path: %symfony_cmf_routing_extra.route_basepath%
```

We can also avoid this problem by prefixing this path automaticaly, which would make semantical sense in a way, at the cost of increasing the complexity of the provider code a little.
