### PR TITLE
Changed computeSingleDocumentChangeset to computeChangeSet

### DIFF
--- a/EventListener/AutoRouteListener.php
+++ b/EventListener/AutoRouteListener.php
@@ -39,7 +39,13 @@ class AutoRouteListener
                 $context = $this->getArm()->updateAutoRouteForDocument($document);
                 foreach ($context->getRoutes() as $route) {
                     $dm->persist($route);
-                    $uow->computeSingleDocumentChangeSet($route);
+
+                    // this was originally computeSingleDocumentChangeset
+                    // however this caused problems in a real usecase
+                    // (functional tests were fine)
+                    //
+                    // this is probably not very efficient, but it works
+                    $uow->computeChangeSets();
                 }
             }
         }


### PR DESCRIPTION
I will merge this PR but just want to log the problem for reference. I think maybe that this might not even be a hack, but the right thing to do.

When saving a Blog in SonataAdmin with RoutingAuto enabled I was getting the following were "dtls-blog" was the original name and "renamed" was the new name.

```
[... ] "renamed" is not a valid child of node [...]
at NodeHelper ::orderBeforeArray ('home', 'renamed', array('dtls-blog', 'home'))
in /home/daniel/www/travelblog/vendor/jackalope/jackalope/src/Jackalope/Node.php at line 453  -+
at Node ->orderBefore ('home', 'renamed')
in /home/daniel/www/travelblog/vendor/doctrine/phpcr-odm/lib/Doctrine/ODM/PHPCR/UnitOfWork.php at line 2145  -+
at UnitOfWork ->executeUpdates (array('000000003244ee220000000098db5f4f' => object(Blog), '000000003244ef150000000098db5f4f' => object(Generic), '000000003244e88d0000000098db5f4f' => object(AutoRoute)))
in /home/daniel/www/travelblog/vendor/doctrine/phpcr-odm/lib/Doctrine/ODM/PHPCR/UnitOfWork.php at line 1756
```

This is also related to PR : https://github.com/doctrine/phpcr-odm/pull/277

Which is _possibly_ related to this problem.
