### PR TITLE
Small fix to handle parent ID strategy mappings

### DIFF
--- a/AutoRoute/RouteMaker/AutoRouteMaker.php
+++ b/AutoRoute/RouteMaker/AutoRouteMaker.php
@@ -97,8 +97,7 @@ class AutoRouteMaker implements RouteMakerInterface
 
     protected function documentIsPersisted($document)
     {
-        $metadata = $this->dm->getClassMetadata(get_class($document));
-        $id = $metadata->getIdentifierValue($document);
+        $id = $this->dm->getUnitOfWork()->getDocumentId($document);
         $phpcrSession = $this->dm->getPhpcrSession();
         return $phpcrSession->nodeExists($id);
     }

--- a/Tests/Unit/AutoRoute/RouteMaker/AutoRouteMakerTest.php
+++ b/Tests/Unit/AutoRoute/RouteMaker/AutoRouteMakerTest.php
@@ -48,8 +48,8 @@ class AutoRouteMakerTest extends \PHPUnit_Framework_TestCase
     protected function setupDocumentPersisted($isPersisted)
     {
         $this->dm->expects($this->any())
-            ->method('getClassMetadata')
-            ->will($this->returnValue($this->metadata));
+            ->method('getUnitOfWork')
+            ->will($this->returnValue($this->uow));
         $this->dm->expects($this->once())
             ->method('getPhpcrSession')
             ->will($this->returnValue($this->phpcrSession));
@@ -76,10 +76,6 @@ class AutoRouteMakerTest extends \PHPUnit_Framework_TestCase
         $this->builderContext->expects($this->once())
             ->method('getContent')
             ->will($this->returnValue($this->doc));
-
-        $this->dm->expects($this->once())
-            ->method('getUnitOfWork')
-            ->will($this->returnValue($this->uow));
 
         $this->autoRouteStack->expects($this->once())
             ->method('addRoute')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | .. |
| Fixed tickets |  |
| License | MIT |
| Doc PR | n/a |

Uses ->getDocumentId instead of ->getIdentifierValue etc. to determine the ID when finding out if a node already exists.
