### PR TITLE
Added format option for AiPath action

### DIFF
--- a/AutoRoute/PathExists/AutoIncrementPath.php
+++ b/AutoRoute/PathExists/AutoIncrementPath.php
@@ -16,6 +16,7 @@ class AutoIncrementPath implements PathActionInterface
 {
     protected $dm;
     protected $routeMaker;
+    protected $format = '%s-%d';
 
     public function __construct(DocumentManager $dm, RouteMakerInterface $routeMaker)
     {
@@ -25,6 +26,9 @@ class AutoIncrementPath implements PathActionInterface
 
     public function init(array $options)
     {
+        if (isset($options['format'])) {
+            $this->format = '%s'.$options['format'];
+        }
     }
 
     public function execute(RouteStack $routeStack)
@@ -42,7 +46,7 @@ class AutoIncrementPath implements PathActionInterface
         }
 
         do {
-            $newPath = sprintf('%s-%d', $path, $inc++);
+            $newPath = sprintf($this->format, $path, $inc++);
         } while (null !== $this->dm->find(null, $newPath));
 
         $routeStack->replaceLastPathElement(PathHelper::getNodeName($newPath));

--- a/Tests/Unit/AutoRoute/PathExists/AutoIncrementPathTest.php
+++ b/Tests/Unit/AutoRoute/PathExists/AutoIncrementPathTest.php
@@ -124,19 +124,19 @@ class AutoIncrementPathTest extends \PHPUnit_Framework_TestCase
 
         $this->dm->expects($this->at(1))
             ->method('find')
-            ->with(null, '/foo/bar/1')
+            ->with(null, '/foo/bar1')
             ->will($this->returnValue(null));
 
         $this->routeStack->expects($this->once())
             ->method('replaceLastPathElement')
-            ->with('bar/2');
+            ->with('bar1');
 
         $this->routeMaker->expects($this->once())
             ->method('make')
             ->with($this->routeStack);
 
         $aiPath = new AutoIncrementPath($this->dm, $this->routeMaker);
-        $aiPath->init(array('format' => '/%d'));
+        $aiPath->init(array('format' => '%d'));
         $aiPath->execute($this->routeStack);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #45 |
| License | MIT |
| Doc PR | symfony-cmf/symfony-cmf-docs#353 |

As the AiPath action always suffixes, I decided to remove the `%s` from the format option.

Please also note that using a prefix with a slash is not support.
