### PR TITLE
Allow path providers that don't add path elements each time

### DIFF
--- a/AutoRoute/BuilderContext.php
+++ b/AutoRoute/BuilderContext.php
@@ -103,7 +103,10 @@ class BuilderContext
     {
         $paths = array();
         foreach ($this->routeStacks as $routeStack) {
-            $paths[] = $routeStack->getPath();
+            $path = $routeStack->getPath();
+            if (!empty($path)) {
+                $paths[] = $path;
+            }
         }
 
         $path = implode('/', $paths);

--- a/AutoRoute/RouteStack.php
+++ b/AutoRoute/RouteStack.php
@@ -10,7 +10,7 @@ namespace Symfony\Cmf\Bundle\RoutingAutoBundle\AutoRoute;
  */
 class RouteStack
 {
-    protected $pathElements;
+    protected $pathElements = array();
     protected $routes = array();
     protected $context;
     protected $existingRoute;
@@ -90,6 +90,10 @@ class RouteStack
      */
     public function getPaths()
     {
+        if (empty($this->pathElements)) {
+            return array();
+        }
+
         $tmp = array();
 
         foreach ($this->pathElements as $pathElement) {
@@ -135,7 +139,11 @@ class RouteStack
         $fullPath = $this->getPath();
 
         if ($parentPath) {
-            $fullPath = $parentPath.'/'.$fullPath;
+            if (empty($fullPath)) {
+                $fullPath = $parentPath;
+            } else {
+                $fullPath = $parentPath.'/'.$fullPath;
+            }
         }
 
         return $fullPath;

--- a/Tests/Unit/AutoRoute/BuilderContextTest.php
+++ b/Tests/Unit/AutoRoute/BuilderContextTest.php
@@ -25,6 +25,33 @@ class BuilderContextTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $this->builderContext->getRouteStacks());
     }
 
+    public function testIgnoreEmptyPath()
+    {
+        $this->routeStack->expects($this->at(3))
+            ->method('getPath')
+            ->will($this->returnValue('route'));
+
+        $this->routeStack->expects($this->at(4))
+            ->method('getPath')
+            ->will($this->returnValue(''));
+
+        $this->routeStack->expects($this->at(5))
+            ->method('getPath')
+            ->will($this->returnValue('foo/bar'));
+
+        $this->routeStack->expects($this->exactly(3))
+            ->method('isClosed')
+            ->will($this->returnValue(true));
+
+        for ($i = 0; $i < 3; $i++) {
+            $this->builderContext->stageRouteStack($this->routeStack);
+            $this->builderContext->commitRouteStack();
+        }
+
+        $this->assertCount(3, $this->builderContext->getRouteStacks());
+        $this->assertEquals('route/foo/bar', $this->builderContext->getFullPath());
+    }
+
     /**
      * @expectedException \RuntimeException
      */

--- a/Tests/Unit/AutoRoute/RouteStackTest.php
+++ b/Tests/Unit/AutoRoute/RouteStackTest.php
@@ -16,6 +16,12 @@ class RouteStackTest extends \PHPUnit_Framework_TestCase
         $this->route2 = new \stdClass;
     }
 
+    public function testGetEmptyPath()
+    {
+        $this->assertEmpty($this->routeStack->getPaths());
+        $this->assertEquals('', $this->routeStack->getFullPath());
+    }
+
     public function testAddPathElement()
     {
         $this->routeStack->addPathElements(array('foo', 'bar'));


### PR DESCRIPTION
This PR allow path providers to don't add path elements on each `RouteStack` objects.
This simply allow an empty path for `RouteStack`s.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | None. |
| License | MIT |
| Doc PR | None. But could be great to create a doc about custom path providers. |
