### PR TITLE
Make sure that the content_name parent is updated

### DIFF
--- a/AutoRoute/PathProvider/ContentDateTimeProvider.php
+++ b/AutoRoute/PathProvider/ContentDateTimeProvider.php
@@ -47,7 +47,10 @@ class ContentDateTimeProvider extends ContentMethodProvider
         $date = $object->$method();
 
         if (!$date instanceof \DateTime) {
-            throw new \RuntimeException(sprintf('Method %s:%s must return an instance of DateTime.'));
+            throw new \RuntimeException(sprintf('Method %s:%s must return an instance of DateTime.',
+                get_class($object),
+                $method
+            ));
         }
 
         $string = $date->format($this->dateFormat);

--- a/AutoRoute/RouteMaker/AutoRouteMaker.php
+++ b/AutoRoute/RouteMaker/AutoRouteMaker.php
@@ -40,11 +40,11 @@ class AutoRouteMaker implements RouteMakerInterface
 
         if (!$autoRoute) {
             $autoRoute = new AutoRoute;
-            $autoRoute->setParent($context->getTopRoute());
             $autoRoute->setContent($content);
         }
 
         $autoRoute->setName($routeStack->getPath());
+        $autoRoute->setParent($context->getTopRoute());
 
         $routeStack->addRoute($autoRoute);
     }

--- a/Doctrine/Phpcr/AutoRouteListener.php
+++ b/Doctrine/Phpcr/AutoRouteListener.php
@@ -48,6 +48,7 @@ class AutoRouteListener
         $scheduledUpdates = $uow->getScheduledUpdates();
         $updates = array_merge($scheduledInserts, $scheduledUpdates);
 
+        $autoRoute = null;
         foreach ($updates as $document) {
             if ($this->getArm()->isAutoRouteable($document)) {
                 $contexts = $this->getArm()->updateAutoRouteForDocument($document);
@@ -58,6 +59,7 @@ class AutoRouteListener
                     foreach ($context->getRoutes() as $route) {
 
                         if ($route instanceof AutoRoute) {
+                            $autoRoute = $route;
                             $routeParent = $route->getParent();
                             $id = spl_object_hash($routeParent).$route->getName();
                         } else {
@@ -71,14 +73,18 @@ class AutoRouteListener
 
                         $dm->persist($route);
                         $persistedRoutes[$id] = true;
-
-                        // this was originally computeSingleDocumentChangeset
-                        // however this caused problems in a real usecase
-                        // (functional tests were fine)
-                        //
-                        // this is probably not very efficient, but it works
-                        $uow->computeChangeSets();
                     }
+
+                    $uow->computeChangeSets();
+
+                    // For some reason the AutoRoute is not updated even though
+                    // it is persisted above. Re-persisting and recomputing the
+                    // changesets makes this work.
+                    if (null !== $autoRoute) {
+                        $dm->persist($autoRoute);
+                    }
+
+                    $uow->computeChangeSets();
                 }
             }
         }

--- a/Tests/Functional/Command/RefreshCommandTest.php
+++ b/Tests/Functional/Command/RefreshCommandTest.php
@@ -35,6 +35,7 @@ class RefreshCommandTest extends BaseTestCase
             $post->title = 'This is a post title';
             $post->body = 'Test Body';
             $post->blog = $blog;
+            $post->date = new \DateTime('2013/03/21');
             $this->getDm()->persist($post);
         }
 

--- a/Tests/Functional/EventListener/AutoRouteListenerTest.php
+++ b/Tests/Functional/EventListener/AutoRouteListenerTest.php
@@ -32,6 +32,7 @@ class AutoRouteListenerTest extends BaseTestCase
             $post = new Post;
             $post->title = 'This is a post title';
             $post->blog = $blog;
+            $post->date = new \DateTime('2013/03/21');
             $this->getDm()->persist($post);
         }
 
@@ -158,15 +159,27 @@ class AutoRouteListenerTest extends BaseTestCase
 
         // make sure auto-route references content
         $post = $this->getDm()->find(null, '/test/test-blog/This is a post title');
-        $post->title = "This is different";
+        $post->title = 'This is different';
+
+        // test for issue #52
+        $post->date = new \DateTime('2014-01-25');
+
         $this->getDm()->persist($post);
         $this->getDm()->flush();
 
         $routes = $this->getDm()->getReferrers($post);
 
         $this->assertCount(1, $routes);
-        $this->assertInstanceOf('Symfony\Cmf\Bundle\RoutingAutoBundle\Model\AutoRoute', $routes[0]);
-        $this->assertEquals('this-is-different', $routes[0]->getName());
+        $route = $routes[0];
+
+        $this->assertInstanceOf('Symfony\Cmf\Bundle\RoutingAutoBundle\Model\AutoRoute', $route);
+        $this->assertEquals('this-is-different', $route->getName());
+
+        $node = $this->getDm()->getNodeForDocument($route);
+        $this->assertEquals(
+            '/test/auto-route/blog/unit-testing-blog/2014/01/25/this-is-different',
+            $node->getPath()
+        );
     }
 
     public function provideMultilangArticle()

--- a/Tests/Resources/Document/Post.php
+++ b/Tests/Resources/Document/Post.php
@@ -48,6 +48,11 @@ class Post
      */
     public $body;
 
+    /**
+     * @PHPCR\Date(nullable=true)
+     */
+    public $date;
+
     public function getTitle()
     {
         return $this->title;
@@ -60,6 +65,6 @@ class Post
 
     public function getDate()
     {
-        return new \DateTime('2013/03/21');
+        return $this->date;;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #42 |
| License | MIT |
| Doc PR |  |

Make sure that the content_name parent is updated
When the content_path route has changed
- Fixes #52
