### PR TITLE
Enable tests to be run as a dependency

### DIFF
--- a/Tests/Resources/app/config/config.php
+++ b/Tests/Resources/app/config/config.php
@@ -1,5 +1,8 @@
 <?php
 
+$container->setParameter('cmf_testing.bundle_name', 'RoutingAutoBundle');
+$container->setParameter('cmf_testing.bundle_fqn', 'Symfony\Cmf\Bundle\RoutingAutoBundle');
+
 $loader->import(CMF_TEST_CONFIG_DIR.'/default.php');
 $loader->import(CMF_TEST_CONFIG_DIR.'/phpcr_odm.php');
 $loader->import(__DIR__.'/app_config.yml');


### PR DESCRIPTION
This change explicitly sets the bundle name and FQN for the testing component and allows the Functional tests to be run from the vendor direcory..
