### PR TITLE
Renamed the default mapping name

### DIFF
--- a/DependencyInjection/CmfRoutingAutoExtension.php
+++ b/DependencyInjection/CmfRoutingAutoExtension.php
@@ -60,7 +60,7 @@ class CmfRoutingAutoExtension extends Extension
         foreach ($bundles as $bundle) {
             $obj = new $bundle;
             foreach (array('xml', 'yml') as $extension) {
-                $path = $obj->getPath().'/Resources/config/auto_routing.'.$extension;
+                $path = $obj->getPath().'/Resources/config/cmf_routing_auto.'.$extension;
                 if (file_exists($path)) {
                     $resources[] = array('path' => $path, 'type' => null);
                 }


### PR DESCRIPTION
I think `cmf_routing_auto.{yml|xml}` makes more sense then `auto_routing` - it reflacts the name of the bundle.
