### PR TITLE
throw exception if the base path node does not exist

### DIFF
--- a/Adapter/PhpcrOdmAdapter.php
+++ b/Adapter/PhpcrOdmAdapter.php
@@ -119,7 +119,7 @@ class PhpcrOdmAdapter implements AdapterInterface
         $path = $this->baseRoutePath;
         $document = $parentDocument = $this->dm->find(null, $path);
         if (null === $parentDocument) {
-            throw new \RuntimeException(sprintf('The "route_basepath" configuration points to a non existant path "%s".',
+            throw new \RuntimeException(sprintf('The "route_basepath" configuration points to a non-existant path "%s".',
                 $path
             ));
         }

--- a/Tests/Unit/Adapter/PhpcrOdmAdapterTest.php
+++ b/Tests/Unit/Adapter/PhpcrOdmAdapterTest.php
@@ -126,6 +126,18 @@ class PhpcrOdmAdapterTest extends BaseTestCase
         $this->assertSame($this->contentDocument, $res->getContent());
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage configuration points to a non-existant path
+     */
+    public function testCreateAutoRouteNonExistingBasePath()
+    {
+        $this->dm->getPhpcrSession()->willReturn($this->phpcrSession);
+        $this->dm->find(null, $this->baseRoutePath)->willReturn(null);
+        $this->adapter->createAutoRoute('/foo', $this->contentDocument, 'fr');
+    }
+
+
     public function testGetRealClassName()
     {
         $res = $this->adapter->getRealClassName('Class/Foo');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony-cmf/RoutingAutoBundle/issues/129 |
| License | MIT |
| Doc PR | - |
