### PR TITLE
Updated version of symfony-cmf/routing-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "dev",
     "require": {
         "symfony-cmf/routing-auto": "~1.0",
-        "symfony-cmf/routing-bundle": "~1.2",
+        "symfony-cmf/routing-bundle": "~1.3",
         "symfony-cmf/core-bundle": "~1.2",
         "aferrandini/urlizer": "1.0.*",
         "symfony/config": "~2.2",


### PR DESCRIPTION
Updated `symfony-cmf/routing-bundle` version

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | symfony-cmf/cmf-sandbox#276 |
| License | MIT |
| Doc PR |  |
