### PR TITLE
Improve Travis setup and add symfony 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,28 +12,24 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
-env:
-  - SYMFONY_VERSION=2.7.* SYMFONY_DEPRECATIONS_HELPER=weak
+env: SYMFONY_VERSION=2.8.*
 
 matrix:
   include:
+    - php: 7.0
+      env: DEPS=dev SYMFONY_VERSION=3.1.*
     - php: 5.5
-      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
-    - php: 5.6
-      env: SYMFONY_VERSION=2.3.* SYMFONY_DEPRECATIONS_HELPER=weak
-    - php: 5.6
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.0.*
-  allow_failures:
-    - env: SYMFONY_VERSION=2.8.*
-    - env: SYMFONY_VERSION=3.0.*
+      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
+    - php: 7.0
+      env: DEPS=dev COMPOSER_FLAGS="--prefer-stable" SYMFONY_VERSION=3.0.*
   fast_finish: true
 
 before_install:
-  - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
+  - phpenv config-rm xdebug.ini || true
   - composer selfupdate
-  - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
+  - if [ "$DEPS" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
 
 install: composer update $COMPOSER_FLAGS --prefer-dist
 

--- a/Adapter/PhpcrOdmAdapter.php
+++ b/Adapter/PhpcrOdmAdapter.php
@@ -160,7 +160,7 @@ class PhpcrOdmAdapter implements AdapterInterface
         $headRoute = new $this->autoRouteFqcn();
         $headRoute->setContent($contentDocument);
         $headRoute->setName($headName);
-        $headRoute->setParent($document);
+        $headRoute->setParentDocument($document);
         $headRoute->setAutoRouteTag($autoRouteTag);
         $headRoute->setType(AutoRouteInterface::TYPE_PRIMARY);
 

--- a/Resources/config/auto_route.xml
+++ b/Resources/config/auto_route.xml
@@ -87,9 +87,9 @@
         </service>
 
         <service id="cmf_routing_auto.metadata.factory"
-            class="%cmf_routing_auto.metadata.factory.class%"
-            factory-service="cmf_routing_auto.metadata.factory.builder"
-            factory-method="getMetadataFactory" />
+            class="%cmf_routing_auto.metadata.factory.class%">
+            <factory service="cmf_routing_auto.metadata.factory.builder" method="getMetadataFactory" />
+        </service>
 
         <!-- Controller -->
         <service 

--- a/Tests/Functional/EventListener/AutoRouteListenerTest.php
+++ b/Tests/Functional/EventListener/AutoRouteListenerTest.php
@@ -467,7 +467,7 @@ class AutoRouteListenerTest extends BaseTestCase
         $parentRoute = $this->getDm()->find(null, '/test/auto-route/seo-articles/hai');
         $childRoute = new AutoRoute();
         $childRoute->setName('foo');
-        $childRoute->setParent($parentRoute);
+        $childRoute->setParentDocument($parentRoute);
         $this->getDm()->persist($childRoute);
         $this->getDm()->flush();
 

--- a/Tests/Resources/app/config/app_config.yml
+++ b/Tests/Resources/app/config/app_config.yml
@@ -10,7 +10,7 @@ cmf_routing:
         persistence:
             phpcr:
                 enabled: true
-                route_basepath: /test/auto-route
+                route_basepaths: [/test/auto-route]
 
 cmf_routing_auto:
     auto_mapping: false
@@ -19,4 +19,4 @@ cmf_routing_auto:
             route_basepath: /test/auto-route
     mapping:
         resources:
-            - @CmfRoutingAutoBundle/Tests/Resources/app/config/routing_auto.yml
+            - '@CmfRoutingAutoBundle/Tests/Resources/app/config/routing_auto.yml'

--- a/Tests/Unit/Adapter/PhpcrOdmAdapterTest.php
+++ b/Tests/Unit/Adapter/PhpcrOdmAdapterTest.php
@@ -123,7 +123,7 @@ class PhpcrOdmAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Cmf\Bundle\RoutingAutoBundle\Model\AutoRoute', $res);
         $this->assertEquals($expectedName, $res->getName());
 
-        $this->assertSame($this->parentRoute, $res->getParent());
+        $this->assertSame($this->parentRoute, $res->getParentDocument());
         $this->assertSame($this->contentDocument, $res->getContent());
     }
 
@@ -158,7 +158,7 @@ class PhpcrOdmAdapterTest extends \PHPUnit_Framework_TestCase
             'two' => 'k2',
         ), $res->getDefaults());
 
-        $this->assertSame($this->parentRoute, $res->getParent());
+        $this->assertSame($this->parentRoute, $res->getParentDocument());
         $this->assertSame($this->contentDocument, $res->getContent());
     }
 

--- a/composer.json
+++ b/composer.json
@@ -6,28 +6,25 @@
     "authors": [
         {
             "name": "Symfony CMF Community",
-            "homepage": "https://github.com/symfony-cmf/symfony-cmf/contributors"
+            "homepage": "https://github.com/symfony-cmf/routing-auto-bundle/contributors"
         }
     ],
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "require": {
-        "php": "^5.5.0|^7.0",
+        "php": "^5.5.9|^7.0",
+        "symfony/framework-bundle": "^2.8|^3.0",
+        "symfony/config": "^2.8|^3.0",
         "symfony-cmf/routing-auto": "^2.0@dev",
-        "symfony-cmf/routing-bundle": "^1.2.0",
+        "symfony-cmf/routing-bundle": "^1.2.0|^2.0",
         "symfony-cmf/slugifier-api": "^1.0",
         "aferrandini/urlizer": "1.0.*",
-        "symfony/config": "^2.2",
         "jms/metadata": "1.5.*"
     },
     "require-dev": {
         "symfony-cmf/testing": "^1.3",
-        "symfony/yaml": "^2.1",
+        "symfony/yaml": "^2.8|^3.0",
         "matthiasnoback/symfony-dependency-injection-test": "~0.6",
-        "matthiasnoback/symfony-config-test": "0.*",
-        "doctrine/phpcr-odm": "^1.3",
-        "phpunit/phpunit": "^4.5",
-        "symfony/phpunit-bridge": "^2.7"
+        "matthiasnoback/symfony-config-test": "^1.3.1",
+        "doctrine/phpcr-odm": "^1.3"
     },
     "suggest": {
         "doctrine/phpcr-odm": "To enable support for the PHPCR ODM documents",


### PR DESCRIPTION
There is one problem with Symfony 3 support: The RoutingAuto component needs a BC break as the typehint has to change from `OptionsResolverInterface` to `OptionsResolver`. This will still be compatible with 2.3 and 3.0. /cc @dantleech do you think we can apply this BC break to the next version of RoutingAuto?