### PR TITLE
Follow naming changes made in component.

### DIFF
--- a/src/Adapter/PhpcrOdmAdapter.php
+++ b/src/Adapter/PhpcrOdmAdapter.php
@@ -109,7 +109,7 @@ class PhpcrOdmAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function createAutoRoute(UriContext $uriContext, $contentDocument, $autoRouteTag)
+    public function createAutoRoute(UriContext $uriContext, $contentDocument, $locale)
     {
         $basePath = $this->baseRoutePath;
         $document = $parentDocument = $this->dm->find(null, $basePath);
@@ -142,7 +142,7 @@ class PhpcrOdmAdapter implements AdapterInterface
                 return $this->migrateGenericToAutoRoute(
                     $existingDocument,
                     $contentDocument,
-                    $autoRouteTag,
+                    $locale,
                     AutoRouteInterface::TYPE_PRIMARY
                 );
             }
@@ -161,7 +161,7 @@ class PhpcrOdmAdapter implements AdapterInterface
         $headRoute->setContent($contentDocument);
         $headRoute->setName($headName);
         $headRoute->setParentDocument($document);
-        $headRoute->setAutoRouteTag($autoRouteTag);
+        $headRoute->setLocale($locale);
         $headRoute->setType(AutoRouteInterface::TYPE_PRIMARY);
 
         foreach ($uriContext->getDefaults() as $key => $value) {
@@ -229,12 +229,12 @@ class PhpcrOdmAdapter implements AdapterInterface
      *
      * @param Generic $document
      * @param object  $contentDocument
-     * @param string  $autoRouteTag
+     * @param string  $locale
      * @param string  $routeType
      *
      * @return AutoRouteInterface
      */
-    private function migrateGenericToAutoRoute(Generic $document, $contentDocument, $autoRouteTag, $routeType)
+    private function migrateGenericToAutoRoute(Generic $document, $contentDocument, $locale, $routeType)
     {
         $autoRouteClassName = $this->autoRouteFqcn;
         $mapper = $this->dm->getConfiguration()->getDocumentClassMapper();
@@ -256,7 +256,7 @@ class PhpcrOdmAdapter implements AdapterInterface
         }
 
         $autoRoute->setContent($contentDocument);
-        $autoRoute->setAutoRouteTag($autoRouteTag);
+        $autoRoute->setLocale($locale);
         $autoRoute->setType($routeType);
 
         return $autoRoute;

--- a/src/Model/AutoRoute.php
+++ b/src/Model/AutoRoute.php
@@ -22,7 +22,7 @@ use Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface;
  */
 class AutoRoute extends Route implements AutoRouteInterface
 {
-    const DEFAULT_KEY_AUTO_ROUTE_TAG = '_auto_route_tag';
+    const DEFAULT_KEY_AUTO_ROUTE_LOCALE = '_auto_route_tag';
 
     /**
      * @var AutoRouteInterface
@@ -32,17 +32,17 @@ class AutoRoute extends Route implements AutoRouteInterface
     /**
      * {@inheritdoc}
      */
-    public function setAutoRouteTag($autoRouteTag)
+    public function setAutoRouteLocale($autoRouteLocale)
     {
-        $this->setDefault(self::DEFAULT_KEY_AUTO_ROUTE_TAG, $autoRouteTag);
+        $this->setDefault(self::DEFAULT_KEY_AUTO_ROUTE_LOCALE, $autoRouteLocale);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getAutoRouteTag()
+    public function getAutoRouteLocale()
     {
-        return $this->getDefault(self::DEFAULT_KEY_AUTO_ROUTE_TAG);
+        return $this->getDefault(self::DEFAULT_KEY_AUTO_ROUTE_LOCALE);
     }
 
     /**

--- a/src/Model/AutoRoute.php
+++ b/src/Model/AutoRoute.php
@@ -32,7 +32,7 @@ class AutoRoute extends Route implements AutoRouteInterface
     /**
      * {@inheritdoc}
      */
-    public function setAutoRouteLocale($autoRouteLocale)
+    public function setLocale($autoRouteLocale)
     {
         $this->setDefault(self::DEFAULT_KEY_AUTO_ROUTE_LOCALE, $autoRouteLocale);
     }
@@ -40,7 +40,7 @@ class AutoRoute extends Route implements AutoRouteInterface
     /**
      * {@inheritdoc}
      */
-    public function getAutoRouteLocale()
+    public function getLocale()
     {
         return $this->getDefault(self::DEFAULT_KEY_AUTO_ROUTE_LOCALE);
     }

--- a/src/Model/AutoRoute.php
+++ b/src/Model/AutoRoute.php
@@ -32,9 +32,9 @@ class AutoRoute extends Route implements AutoRouteInterface
     /**
      * {@inheritdoc}
      */
-    public function setLocale($autoRouteLocale)
+    public function setLocale($locale)
     {
-        $this->setDefault(self::DEFAULT_KEY_AUTO_ROUTE_LOCALE, $autoRouteLocale);
+        $this->setDefault(self::DEFAULT_KEY_AUTO_ROUTE_LOCALE, $locale);
     }
 
     /**

--- a/tests/Functional/EventListener/AutoRouteListenerTest.php
+++ b/tests/Functional/EventListener/AutoRouteListenerTest.php
@@ -65,7 +65,7 @@ class AutoRouteListenerTest extends BaseTestCase
         $this->assertCount(1, $routes);
         $this->assertInstanceOf('Symfony\Cmf\Bundle\RoutingAutoBundle\Model\AutoRoute', $routes[0]);
         $this->assertEquals('unit-testing-blog', $routes[0]->getName());
-        $this->assertEquals(PhpcrOdmAdapter::TAG_NO_MULTILANG, $routes[0]->getAutoRouteTag());
+        $this->assertEquals(PhpcrOdmAdapter::TAG_NO_MULTILANG, $routes[0]->getLocale());
         $this->assertEquals(array(
             '_auto_route_tag' => 'no-multilang',
             'type' => 'cmf_routing_auto.primary',
@@ -257,7 +257,7 @@ class AutoRouteListenerTest extends BaseTestCase
 
             $this->assertNotNull($route, 'Route: '.$expectedPath);
             $this->assertInstanceOf('Symfony\Cmf\Bundle\RoutingAutoBundle\Model\AutoRoute', $route);
-            $this->assertEquals($expectedLocale, $route->getAutoRouteTag());
+            $this->assertEquals($expectedLocale, $route->getLocale());
 
             $content = $route->getContent();
 


### PR DESCRIPTION
Follow naming changes made in routing-auto component with symfony-cmf/routing-auto@cffb517190c75b92672d0dbd45369f34af5d135b .