### PR TITLE
Validate the cmf_routing_auto.adapter configuration option.

### DIFF
--- a/src/Resources/config/schema/routing-auto-1.0.xsd
+++ b/src/Resources/config/schema/routing-auto-1.0.xsd
@@ -14,6 +14,7 @@
         </xsd:sequence>
 
         <xsd:attribute name="auto-mapping" type="xsd:boolean" />
+        <xsd:attribute name="adapter" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="persistence">


### PR DESCRIPTION
The cmf_routing_auto.adapter configuration is handled by the bundle. But it isn't or validated by the schema.