### PR TITLE
Implement the changes made in symfony-cmf/routing-auto#91

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-Tests/Resources/app/cache
-Tests/Resources/app/logs
+tests/Resources/app/cache
+tests/Resources/app/logs
 composer.lock
 vendor

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,6 @@
         "matthiasnoback/symfony-config-test": "^1.3.1",
         "doctrine/phpcr-odm": "^1.3"
     },
-    "minimum-stability": "RC",
-    "prefer-stable": true,
     "suggest": {
         "doctrine/phpcr-odm": "To enable support for the PHPCR ODM documents",
         "doctrine/phpcr-bundle": "To enable support for the PHPCR ODM documents",

--- a/composer.json
+++ b/composer.json
@@ -45,5 +45,11 @@
         "branch-alias": {
             "dev-master": "2.0-dev"
         }
+    },
+    "scripts": {
+        "test": [
+            "vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh",
+            "SYMFONY_PHPUNIT_REMOVE=\"symfony/yaml\" vendor/bin/simple-phpunit"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^5.6|^7.0",
         "symfony/framework-bundle": "^2.8|^3.0",
-        "symfony-cmf/routing-auto": "^2.0",
+        "symfony-cmf/routing-auto": "^2.0.0-RC2",
         "symfony-cmf/routing-bundle": "^1.2.0|^2.0",
         "aferrandini/urlizer": "1.0.*"
     },

--- a/src/Adapter/PhpcrOdmAdapter.php
+++ b/src/Adapter/PhpcrOdmAdapter.php
@@ -203,6 +203,20 @@ class PhpcrOdmAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
+    public function compareAutoRouteLocale(AutoRouteInterface $autoRoute, $locale)
+    {
+        $autoRouteLocale = $autoRoute->getLocale();
+
+        if ($autoRouteLocale === self::TAG_NO_MULTILANG) {
+            $autoRouteLocale = null;
+        }
+
+        return $autoRouteLocale === $locale;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getReferringAutoRoutes($contentDocument)
     {
         return $this->dm->getReferrers($contentDocument, null, null, null, 'Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface');

--- a/tests/Functional/EventListener/AutoRouteListenerTest.php
+++ b/tests/Functional/EventListener/AutoRouteListenerTest.php
@@ -17,6 +17,7 @@ use Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Functional\BaseTestCase;
 use Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\Article;
 use Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\Blog;
 use Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\ConcreteContent;
+use Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\ConflictProneArticle;
 use Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\Page;
 use Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\Post;
 use Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\SeoArticle;
@@ -357,6 +358,26 @@ class AutoRouteListenerTest extends BaseTestCase
             // We havn't loaded the translation for the document, so it is always in the default language
             $this->assertEquals('Hello everybody!', $content->title);
         }
+    }
+
+    public function testResolveConflictOnSingleMultilangArticle()
+    {
+        $article = new ConflictProneArticle();
+        $article->path = '/test/article';
+        $article->title = 'Weekend';
+        $this->getDm()->persist($article);
+        $this->getDm()->bindTranslation($article, 'fr');
+
+        $article->title = 'Weekend';
+        $this->getDm()->bindTranslation($article, 'en');
+
+        $this->getDm()->flush();
+
+        $route = $this->getDm()->find(AutoRoute::class, 'test/auto-route/conflict-prone-articles/weekend');
+        $this->assertNotNull($route);
+
+        $route = $this->getDm()->find(AutoRoute::class, 'test/auto-route/conflict-prone-articles/weekend-1');
+        $this->assertNotNull($route);
     }
 
     public function provideLeaveRedirect()

--- a/tests/Resources/Document/ConflictProneArticle.php
+++ b/tests/Resources/Document/ConflictProneArticle.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2017 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
+
+/**
+ * @PHPCR\Document(translator="child", referenceable=true)
+ */
+class ConflictProneArticle extends Article
+{
+}

--- a/tests/Resources/app/config/routing_auto.yml
+++ b/tests/Resources/app/config/routing_auto.yml
@@ -8,8 +8,8 @@ Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\Blog:
         blog_title: [content_method, { method: getTitle } ]
 
 Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\Post:
-    definitions: 
-        view: 
+    definitions:
+        view:
             uri_schema: /blog/{blog_title}/{post_date}/{post_title}
     token_providers:
         blog_title: [content_method, { method: getBlogTitle } ]
@@ -18,7 +18,7 @@ Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\Post:
     conflict_resolver: [auto_increment, { }]
 
 Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\Article:
-    definitions: 
+    definitions:
         view:
             uri_schema: /articles/{article_locale}/{article_title}
             defaults:
@@ -34,6 +34,14 @@ Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\Article:
     token_providers:
         article_title: [content_method, { method: getTitle } ]
         article_locale: [content_locale, {} ]
+
+Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\ConflictProneArticle:
+    definitions:
+        view:
+            uri_schema: /conflict-prone-articles/{article_title}
+    token_providers:
+        article_title: [content_method, { method: getTitle } ]
+    conflict_resolver: [auto_increment]
 
 Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\SeoArticle:
     definitions:

--- a/tests/Unit/Adapter/PhpcrOdmAdapterTest.php
+++ b/tests/Unit/Adapter/PhpcrOdmAdapterTest.php
@@ -224,6 +224,44 @@ class PhpcrOdmAdapterTest extends \PHPUnit_Framework_TestCase
         $this->adapter->compareAutoRouteContent($this->route->reveal(), $this->contentDocument);
     }
 
+    public function provideCompareAutoRouteLocale()
+    {
+        return [
+            'a not localized route and a null locale' => [
+                PhpcrOdmAdapter::TAG_NO_MULTILANG,
+                null,
+                true,
+            ],
+            'a not localized route and a locale' => [
+                PhpcrOdmAdapter::TAG_NO_MULTILANG,
+                'en',
+                false,
+            ],
+            'a localized route and the matching locale' => [
+                'en',
+                'en',
+                true,
+            ],
+            'a localized route and a not matching locale' => [
+                'en',
+                'fr',
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideCompareAutoRouteLocale
+     */
+    public function testCompareAutoRouteLocale($autoRouteLocale, $locale, $shouldMatch)
+    {
+        $this->route->getLocale()->willReturn($autoRouteLocale);
+
+        $areMatching = $this->adapter->compareAutoRouteLocale($this->route->reveal(), $locale);
+
+        $this->assertSame($shouldMatch, $areMatching);
+    }
+
     public function testGetReferringRoutes()
     {
         $this->dm->getReferrers($this->contentDocument, null, null, null, 'Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface')


### PR DESCRIPTION
This PR:
 - fixes the _.gitignore_ file in order to REALLY ignore the cache/logs directories of the testing app,
 - adds a Composer script to run the tests as configured in the _.travis.yml_ file (can be run using `composer test`)
 - implements the new `AdapterInterface::compareAutoRouteLocale` method added by symfony-cmf/routing-auto#91.