### PR TITLE
Travis refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 matrix:
   include:
     - php: 7.1
-      env: DEPS=dev SYMFONY_VERSION=3.3.*
+      env: SYMFONY_VERSION=3.3.* STABILITY=dev
     - php: 5.6
       env: SYMFONY_VERSION=2.8.* COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 7.1
@@ -29,7 +29,7 @@ before_install:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
   - phpenv config-rm xdebug.ini || true
   - composer selfupdate
-  - if [ "$DEPS" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi
+  - ${STABILITY:+ composer config 'minimum-stability' "$STABILITY"}
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
 
 install: composer update $COMPOSER_FLAGS --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,11 @@ matrix:
 before_install:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
   - phpenv config-rm xdebug.ini || true
-  - composer selfupdate
+  - composer self-update
   - ${STABILITY:+ composer config 'minimum-stability' "$STABILITY"}
   - ${SYMFONY_VERSION:+ composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update}
 
-install: composer update $COMPOSER_FLAGS --prefer-dist
+install: composer update --prefer-dist $COMPOSER_FLAGS
 
 before_script: vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - phpenv config-rm xdebug.ini || true
   - composer selfupdate
   - ${STABILITY:+ composer config 'minimum-stability' "$STABILITY"}
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
+  - ${SYMFONY_VERSION:+ composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update}
 
 install: composer update $COMPOSER_FLAGS --prefer-dist
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,12 @@ cache:
     - .phpunit
 
 env:
-  matrix: SYMFONY_VERSION=3.2.*
-  global: SYMFONY_PHPUNIT_DIR=.phpunit SYMFONY_PHPUNIT_REMOVE="symfony/yaml"
+  matrix:
+    - SYMFONY_VERSION=3.2.*
+  global:
+    - SYMFONY_PHPUNIT_DIR=.phpunit
+    - SYMFONY_PHPUNIT_REMOVE="symfony/yaml"
+    - SYMFONY_PHPUNIT_VERSION=5.7
 
 matrix:
   include:


### PR DESCRIPTION
I investigated about the need to remove the PHP memory limit modification as it is not present in the component Travis configuration file.

# Test memory consumption

| Binary | Tests run |
|---|---:|
| PHP 5.6 | 66 MB |
| PHP 7 | 42 MB |
| PHP 7.1 | 28 MB |
| HHVM | 102 MB |

# Composer memory consumption

| Binary | Self update | Dependencies update |
|---|---|---|
| PHP 5.6 | 11 MB | 892 MB |
| PHP 7 | 7 MB | 505 MB |
| PHP 7.1 | 2.4 MB | 494 MB|
| HHVM | 6 MB | 384 MB |

I know it's not a benchmark but it shows that the default PHP memory limit on Travis Trusty machines (1 GB) is sufficient for the tests. Composer obviously consumes a lot of RAM and the default limit might be reached some day.

I don't like the one-liner used to disable the PHP memory limit. Using an INI file might be more pleasant. But as it's the only overriden PHP configuration directive and this one-liner come from the official Travis documentation, I kept it as this.
